### PR TITLE
Tweaked navigation to fix max widths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,8 @@ import RaidProgression from "./components/RaidProgression";
 const App = () => {
   return (
     <div className="App font-nunito h-full bg-purple text-gold">
-      <main className="max-w-5xl mx-auto flex flex-col gap-y-8 py-8">
-        <Nav />
+      <Nav />
+      <main className="max-w-5xl mx-auto flex flex-col gap-y-8 pb-8">
         <HeroBanner />
         <FeatureList />
         <Discord />

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -51,13 +51,13 @@ const Nav = () => {
         {/* position: absolute removes it from the visual flow, while still intersecting with viewport */}
       </div>
       <header
-        className={`sticky top-0 py-4 z-10 max-w-none w-[100vw] ml-[50%] translate-x-[-50%] ${
+        className={`sticky top-0 py-8 z-10 max-w-none w-full ml-[50%] translate-x-[-50%] ${
           navHasBackground &&
           "bg-purple/80 ease-in duration-300 backdrop-blur-sm"
         }`}
         id="navbar"
       >
-        <nav className="flex justify-around" id="nav">
+        <nav className="max-w-5xl mx-auto flex justify-between" id="nav">
           <img
             className="cursor-pointer"
             onClick={() => scrollToView("#home")}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,74 +1,102 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import logo from "@/assets/logo-ipsum-nav.svg";
 
 const Nav = () => {
   const navItems = [
-    { name: "Home", selector: "#home" },
-    { name: "Join us", selector: "#join-us" },
-    { name: "Raid progression", selector: "#raid-progression" },
-    { name: "Bruxy's Corner", selector: "#corner" },
+    { id: "home", name: "Home" },
+    { id: "join-us", name: "Join us" },
+    { id: "raid-progression", name: "Raid Progression" },
+    { id: "corner", name: "Bruxy's Corner" },
   ] as const;
 
-  const scrollToView = (selector: (typeof navItems)[number]["selector"]) => {
-    const element = document.querySelector(selector);
+  const scrollToView = (id: (typeof navItems)[number]["id"]) => {
+    const element = document.getElementById(id);
     if (element) {
       element.scrollIntoView({ behavior: "smooth" });
     }
   };
 
-  const startRef = useRef<HTMLDivElement>(null);
-
-  const observer = new IntersectionObserver(
-    (entries: IntersectionObserverEntry[]) => {
-      entries.forEach((entry) => {
-        const id = entry.target.id;
-        if (id === startRef.current?.id) {
-          return handleStart(entry);
-        }
-        // Any other intersection handlers can be added here
-      });
-    },
-    {
-      threshold: 1,
-    }
-  );
-
   const [navHasBackground, setNavHasBackground] = useState(false);
-  const handleStart = (entry: IntersectionObserverEntry) => {
+  const [visibleNavItems, setVisibleNavItems] = useState<string[]>([]);
+  const [activeNavItem, setActiveNavItem] = useState<string | null>(null);
+
+  const observedStart = (entry: IntersectionObserverEntry) => {
     if (entry.isIntersecting) {
       return setNavHasBackground(false);
     }
     return setNavHasBackground(true);
   };
+  const observedNavItems = (entry: IntersectionObserverEntry) => {
+    const id = entry.target.id;
+    if (entry.isIntersecting) {
+      return setVisibleNavItems((items) => [...items, id]);
+    }
+    return setVisibleNavItems((items) => items.filter((item) => item !== id));
+  };
 
+  const observer = new IntersectionObserver(
+    (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        const id = entry.target.id;
+        if (id === "start") {
+          return observedStart(entry);
+        }
+        observedNavItems(entry);
+      });
+    },
+    {
+      threshold: 0.85,
+    }
+  );
+
+  // This effect is to observe the start and nav items
   useEffect(() => {
-    observer.observe(startRef.current as HTMLDivElement);
+    observer.observe(document.getElementById("start") as HTMLDivElement);
+    navItems.forEach(({ id }) => {
+      const element = document.getElementById(id);
+      if (element) {
+        observer.observe(element);
+      }
+    });
   }, []);
+
+  // This effect is to update the active nav item when the visible nav items change
+  // Thanks to https://stackoverflow.com/a/64664382/104380
+  useEffect(() => {
+    return setActiveNavItem(
+      navItems.find(({ id }) => visibleNavItems.includes(id))?.id || null
+    );
+  }, [visibleNavItems]);
 
   return (
     <>
-      <div className="absolute" id="start" ref={startRef}>
+      <div className="absolute" id="start">
         {/* position: absolute removes it from the visual flow, while still intersecting with viewport */}
       </div>
       <header
         className={`sticky top-0 py-8 z-10 max-w-none w-full ml-[50%] translate-x-[-50%] ${
-          navHasBackground &&
-          "bg-purple/80 ease-in duration-300 backdrop-blur-sm"
-        }`}
+          navHasBackground
+            ? "bg-purple/80 ease-in duration-300 backdrop-blur-sm"
+            : ""
+        }`.trim()}
         id="navbar"
       >
         <nav className="max-w-5xl mx-auto flex justify-between" id="nav">
           <img
             className="cursor-pointer"
-            onClick={() => scrollToView("#home")}
+            onClick={() => scrollToView("home")}
             src={logo}
           />
           <ul className="flex items-center">
-            {navItems.map(({ name, selector }) => (
+            {navItems.map(({ name, id }) => (
               <li
-                className="mx-4 cursor-pointer"
-                key={selector.replace("#", "")}
-                onClick={() => scrollToView(selector)}
+                className={`mx-4 cursor-pointer relative before:block before:absolute before:border before:h-px before:top-full before:left-0 before:transition-all before:duration-300 ${
+                  activeNavItem === id
+                    ? "before:right-0 before:opacity-1"
+                    : "before:right-full before:opacity-0"
+                }`.trim()}
+                key={id}
+                onClick={() => scrollToView(id)}
               >
                 {name}
               </li>


### PR DESCRIPTION
Edit: Now also have active nav menu item working

Moved **Nav** up one level, removing the need for viewport based width units. Also clamped the contents max-width to match the flow of the page contents.

I was experiencing a bug where the nav bar would often slightly exceed the width of the page when I had a vertical scrollbar. Moving it up one level and tying it to the width of the parent fixes this.

Also fuck this is looking good.

![Screen Shot 2023-03-24 at 19 34 00](https://user-images.githubusercontent.com/1728144/227611152-0130aa8b-0e0e-492e-81a2-17befd1de334.png)
