### PR TITLE
fix firefox-specific overflow by tweaking nav

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -74,7 +74,7 @@ const Nav = () => {
         {/* position: absolute removes it from the visual flow, while still intersecting with viewport */}
       </div>
       <header
-        className={`sticky top-0 py-8 z-10 max-w-none w-full ml-[50%] translate-x-[-50%] ${
+        className={`sticky top-0 py-8 z-10 max-w-none w-full ${
           navHasBackground
             ? "bg-purple/80 ease-in duration-300 backdrop-blur-sm"
             : ""


### PR DESCRIPTION
Ended up being a simple fix, but a real pain to figure out. Seems like the margin-left and translate-x styles on the nav header were combining to leave a blank space to the right. Chrome was smart enough to figure out that space wasn't needed anymore, but firefox was leaving space where the nav header *would have been* before being translated.

Because the margin and translation seem to have been cancelling each other out, I removed them both, and now everything looks good after checking in firefox, chrome and edge, from what I have tested.