### PR TITLE
Updated the Loth-Divine scale for season 2

### DIFF
--- a/src/pages/loth-divine/[[...params]].tsx
+++ b/src/pages/loth-divine/[[...params]].tsx
@@ -4,7 +4,7 @@ import Image from "@/components/Image";
 import Nav from "@/components/Nav";
 import { useRouter } from "next/router";
 
-const BASE_ILVL = 330;
+const BASE_ILVL = 346;
 const ILVL_STEP = 4;
 const DEFAULT_KEY = 10;
 const DEFAULT_ILVL = BASE_ILVL + DEFAULT_KEY * ILVL_STEP;
@@ -140,8 +140,8 @@ const Home = () => {
               being undergeared to Divine (10) being overgeared.
             </p>
             <p>
-              For example, bringing a 384 ilvl into a +20 dungeon would give you
-              a score of Loth (0). On the other hand, requiring a 420 ilvl for a
+              For example, bringing a 400 ilvl into a +20 dungeon would give you
+              a score of Loth (0). On the other hand, requiring a 436 ilvl for a
               +16 dungeon would give you a score of Divine (10).
             </p>
             <p>


### PR DESCRIPTION
as per Loth, 20/400 for 0 on the scale and 16/436 for 10 sounds good, so the base ilvl has been updated to reflect that