### PR TITLE
Update Xamona's character to Xara

### DIFF
--- a/src/data/raiders.json
+++ b/src/data/raiders.json
@@ -48,7 +48,7 @@
     "realm": "Silvermoon"
   },
   {
-    "characterName": "Xamona",
+    "characterName": "Xara",
     "realm": "Turalyon"
   }
 ]


### PR DESCRIPTION
Xara is the correct main for this season, according to a message in #webdev-nerds.

Verified that the raid data on https://raider.io/characters/eu/turalyon/Xara is current.

Since this change is just to a JSON file, I think merging it straight to `main` seems reasonable in this case.