### PR TITLE
Fix issue #90

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -7,7 +7,7 @@ export const About = ({
   ...rest
 }: React.HTMLProps<HTMLDivElement>) => (
   <div
-    className={`w-full h-full bg-gradient-to-b from-purple via-purple to-blue/25 bg-[length:150%_100%] bg-center flex flex-col gap-8 p-8 md:p-12 rounded-lg ${className}`.trim()}
+    className={`max-w-full h-full bg-gradient-to-b from-purple via-purple to-blue/25 bg-[length:150%_100%] bg-center flex flex-col gap-8 p-8 md:p-12 rounded-lg ${className}`.trim()}
     {...rest}
   >
     <article className="text-left text-yellow-400 flex flex-col gap-6">
@@ -52,6 +52,7 @@ export const About = ({
       aspect-[16/9]
       flex flex-col items-center justify-center
       transition-all duration-300
+      w-full
       `}
       href="/invite"
       rel="noreferrer"

--- a/src/components/Discord/Widget.tsx
+++ b/src/components/Discord/Widget.tsx
@@ -21,9 +21,7 @@ export const Widget = ({ value }: Props) => {
             memberOverflow ? "pointer-events-auto" : "pointer-events-none"
           }`}
         >
-          {members.map((item) => (
-            <User key={item.id} {...item} />
-          ))}
+          {members && members.map((item) => <User key={item.id} {...item} />)}
         </div>
         {!memberOverflow && (
           <div className="absolute text-gold bottom-0 right-0 w-full p-8 bg-purple/80 backdrop-blur-sm">


### PR DESCRIPTION
# Description
This PR fixes the overflowing issue #90 on iPhones by setting a max width instead of a fixed one.
Also, renders the discord members conditionally, if the members object is truthy.

Tested on my iPhone 14 pro
<img src="https://github.com/drunkenvalley/no-pressure/assets/70670201/4322f6cf-610b-4d5b-ac8f-624fb15ccd01" width="256">