### PR TITLE
Disable unnecessary image optimization

### DIFF
--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -29,7 +29,7 @@ const Image = ({ responsive = false, src, width, ...props }: Props) => {
 
   _width = Math.min(_width, screenWidth);
 
-  return <NextImage src={_src} width={_width} {...props} />;
+  return <NextImage src={_src} width={_width} {...props} unoptimized={true} />;
 };
 
 type SizeLabelMapping = {

--- a/src/components/ImageWithFallback.tsx
+++ b/src/components/ImageWithFallback.tsx
@@ -18,6 +18,7 @@ const ImageWithFallback = (props: ImageWithFallbackProps) => {
         setImgSrc(fallbackSrc);
       }}
       src={imgSrc}
+      unoptimized={true}
     />
   );
 };


### PR DESCRIPTION
Just adds `unoptimized={true}`; we already picked small image sizes to avoid long load times on them, and the added layer of image transformations on Vercel is a waste of time.
